### PR TITLE
temp=0 when posting to linkedin

### DIFF
--- a/PodcastSocialMediaCopilot.py
+++ b/PodcastSocialMediaCopilot.py
@@ -290,7 +290,7 @@ print("Calling GPT-4 model with plugin support on Azure OpenAI Service to post t
 payload = {
     "messages": PROMPT_MESSAGES,
     "max_tokens": 1024,
-    "temperature": 0.5,
+    "temperature": 0.0,
     "n": 1,
     "stop": None
 }


### PR DESCRIPTION
Love this demo!

Given that the user has already confirmed a specific message for posting to LinkedIn at this point, is there a reason not to set a low temperature on this final LinkedIn call to limit any surprises?
